### PR TITLE
[ADD]유저 상세페이지 조회 End-Poin 기능 구현

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -2,9 +2,18 @@ const authService = require("../services/authService");
 const ErrorCreater = require("../middlewares/errorCreater");
 
 const logIn = async (req, res) => {
-  
-    const accessToken = req.headers.authorization
-    const token = await authService.logIn(accessToken)
-    res.status(200).json({ accessToken: token })
-              }
-module.exports={logIn}
+    const accessToken = req.headers.authorization;
+    const token = await authService.logIn(accessToken);
+    res.status(200).json({ accessToken: token });
+}
+
+const getUserInfo = async (req, res) => {
+    const userId = req.user.id;
+    const userInfo = await authService.getUserInfo(userId);
+    res.status(200).json({data : userInfo});
+}
+
+module.exports = {
+    logIn,
+    getUserInfo
+}

--- a/models/authDao.js
+++ b/models/authDao.js
@@ -1,8 +1,6 @@
 const { appDataSource } = require("./dataSource");
-const ErrorCreater = require("../middlewares/errorCreater");
 
 const createUser = async (nickname, kakaoId, profileImgUrl) => {
-
   const user = await appDataSource.query(
     `INSERT INTO user (
       nickname,
@@ -15,7 +13,6 @@ const createUser = async (nickname, kakaoId, profileImgUrl) => {
 };
 
 const getUserByKakaoId = async (kakaoId) => {
-
   const [user] = await appDataSource.query(
     `SELECT *
       FROM user u
@@ -27,7 +24,6 @@ const getUserByKakaoId = async (kakaoId) => {
 };
 
 const getUserById = async (userId) => {
-
   const [user] = await appDataSource.query(
     `SELECT *
       FROM user u
@@ -38,4 +34,32 @@ const getUserById = async (userId) => {
   return user;
 };
 
-module.exports = { createUser, getUserByKakaoId, getUserById }
+const getUserInfo = async (userId) => {
+  return await appDataSource.query(`
+  SELECT
+    u.nickname,
+    u.profile_img_url profileUrl,
+    u.kakao_id kakaoId,
+    (
+      SELECT COUNT(follower.follower_id)
+      FROM follower
+      INNER JOIN user
+        ON user.id = follower.following_id
+      WHERE user.id = u.id
+    ) follower,
+    JSON_ARRAYAGG(JSON_OBJECT(
+      'boardId', board.id,
+      'boardTitle', board.title)
+    ) board
+	FROM user u
+	INNER JOIN board
+	  ON u.id = board.user_id
+	WHERE u.id = ?;`, [userId]);
+}
+
+module.exports = {
+  createUser,
+  getUserByKakaoId,
+  getUserById,
+  getUserInfo
+}

--- a/models/boardDao.js
+++ b/models/boardDao.js
@@ -13,7 +13,7 @@ const getBoardTitle = async (userId) => {
     SELECT
         title
     FROM board
-    WEHER user_id = ?;`, [userId])
+    WHERE user_id = ?;`, [userId])
 }
 
 const getUserBoard = async (userId) => {

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -1,9 +1,11 @@
 const express = require("express");
 const authController = require("../controllers/authController");
 const errorHandler = require("../middlewares/errorHandler");
+const auth = require('../middlewares/auth');
 
 const authRouter = express.Router();
 
 authRouter.get("/kakao-login", errorHandler(authController.logIn));
+authRouter.get("/", errorHandler(auth.validationToken), errorHandler(authController.getUserInfo));
 
 module.exports = { authRouter };

--- a/services/authService.js
+++ b/services/authService.js
@@ -6,28 +6,38 @@ const fetch = require('node-fetch')
 const logIn = async (accessToken) => {
 
   const response = await fetch("https://kapi.kakao.com/v2/user/me", {
-        method: "GET",
-        headers: {
-            "Authorization": `Bearer ${accessToken}`,
-            "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-              },
-          })
-            .then(res => res.json())
-            
-          const nickname = response.properties.nickname
-          const kakaoId = response.id
-          const profileImgUrl =response.properties.thumbnail_image
-          
-        if ( !nickname || !kakaoId ) {
-            throw new ErrorCreater("KEY_ERROR", 400)}
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+    },
+  })
+    .then(res => res.json())
 
-    let user = await userDao.getUserByKakaoId(kakaoId); 
-    
-    if (!user) {
-      const result = await userDao.createUser(nickname, kakaoId, profileImgUrl);
-      user = await userDao.getUserById(result.insertId)
+  const nickname = response.properties.nickname
+  const kakaoId = response.id
+  const profileImgUrl = response.properties.thumbnail_image
+
+  if (!nickname || !kakaoId) {
+    throw new ErrorCreater("KEY_ERROR", 400)
+  }
+
+  let user = await userDao.getUserByKakaoId(kakaoId);
+
+  if (!user) {
+    const result = await userDao.createUser(nickname, kakaoId, profileImgUrl);
+    user = await userDao.getUserById(result.insertId)
+  }
+  return jwt.sign({ sub: user.id, exp: Math.floor(Date.now() / 1000) + (600 * 600) }, process.env.JWT_SECRET);
 }
-      return jwt.sign({sub: user.id, exp: Math.floor(Date.now()/1000) + (600*600)}, process.env.JWT_SECRET);
-    }
-  
-  module.exports = {logIn};
+
+const getUserInfo = async(userId) => {
+  const [daoDatas] = await userDao.getUserInfo(userId);
+  daoDatas.board = JSON.parse(daoDatas.board)
+  return daoDatas;
+}
+
+module.exports = {
+  logIn,
+  getUserInfo
+};

--- a/tests/getUserInfo.test.js
+++ b/tests/getUserInfo.test.js
@@ -1,0 +1,47 @@
+const request = require('supertest');
+
+const { createApp } = require('../app');
+const { appDataSource } = require('../models/dataSource');
+const jwt = require('jsonwebtoken');
+
+describe('GET USER DATA', () => {
+    let app;
+    
+    beforeAll(async () => {
+        app = createApp();
+        await appDataSource.initialize();
+    });
+
+    afterAll(async () => {
+        await appDataSource.destroy();
+    });
+
+    test('SUCCESS : Get User Data', async () => {
+        const jwtSpy = jest.spyOn(jwt, 'verify');
+        jwtSpy.mockReturnValue({sub : 1});
+        const res = await request(app)
+            .get('/auth')
+            .set({ Authorization: 'Some Random Token' })
+            .send({id: 1})
+            .expect(200);
+    });
+
+    test('FAIL : Invalid Access Token Error', async () => {
+        const jwtSpy = jest.spyOn(jwt, 'verify');
+        jwtSpy.mockReturnValue({sub : 1});
+        const res = await request(app)
+            .get('/auth')
+            .expect({ message : 'INVALID_ACCESS_TOKEN' })
+            .expect(401)
+    });
+
+    test('FAIL : User Not Defined Error', async () => {
+        const jwtSpy = jest.spyOn(jwt, 'verify');
+        jwtSpy.mockReturnValue({sub : null});
+        const res = await request(app)
+            .get('/auth')
+            .set({ Authorization: 'Some Random Token' })
+            .expect({ message : 'USER_NOT_DEFINED' })
+            .expect(404);
+    });
+});


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 유저 상세페이지 조회 End-Poin 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 유저상세페이지의 정보(KakaoId, profileImage, nickname, boardData)를 전달 해주기 위한 API구현

2. unit test와 postman을 통해 서버 정상 작동 확인 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 해당 기능의 경우 토큰에 대한 검증을 미들웨어에서 모두 진행함으로 코드 작성이 수월하였습니다.
- 토큰을 통해 대부분의 예외처리가 가능하여 해당 기능에서는 특별한 예외 처리 기능을 구현하지 않아도 되어 기능 개발을 빠르게 진행할 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- unit test에서 모든 예외 조건이 토큰에서 발생하여 기존의 다른 test코드와 중복되는 코드들이 많은데 지금처럼 test 코드 파일을 따로 만들어야하는지 궁금합니다.
