### PR TITLE
ADD: pin 삭제와 수정 기능

### DIFF
--- a/controllers/pinController.js
+++ b/controllers/pinController.js
@@ -1,4 +1,5 @@
 const pinService = require('../services/pinService');
+const ErrorCreater = require('../middlewares/errorCreater');
 
 const findMainPins = async(req, res) => {
     const pageSize = Number(req.query.pageSize);
@@ -22,8 +23,32 @@ const getPinInfo = async(req, res) => {
     res.status(200).json(pinInfo);
 }
 
+const deletePin = async (req, res) => {
+    
+    const {pinId} = req.params
+    const userId = req.user.id
+    
+    if(!pinId){
+        throw new ErrorCreater("KEY_ERROR", 400)
+    }
+    await pinService.deletePin(pinId, userId)
+    res.status(200).json({message: "DELETE_SUCCESS"});
+
+}
+
+const patchPin = async(req, res) => {
+    
+    const {pinId} = req.params;
+    const {boardId, title, contents} = req.body
+    const userId = req.user.id
+    
+    if(!pinId || !boardId ||!title) {
+        throw new ErrorCreater("KEY_ERROR", 400)
+    }
+    await pinService.patchPin(pinId, boardId, title, contents, userId);
+    res.status(200).json({message: "PATCH_SUCCESS"});
+} 
+
 module.exports = {
-    findMainPins,
-    findRecommendPins,
-    getPinInfo
+    findMainPins, findRecommendPins, getPinInfo, deletePin, patchPin
 }

--- a/models/pinDao.js
+++ b/models/pinDao.js
@@ -78,8 +78,44 @@ const getPinInfo = async (pinId) => {
 	WHERE p.id = ?;`, [pinId])
 }
 
+const checkMyPin = async(pinId, userId) => {
+  
+    const [myPin] = await appDataSource.query(
+   
+         `SELECT *
+         FROM pin p
+            INNER JOIN board b 
+            ON b.id = p.board_id
+            INNER JOIN user u 
+            ON u.id = b.user_id
+         WHERE p.id = ${pinId} AND u.id = ${userId}
+           `,
+         )
+         return myPin
+   }
+ 
+const deleteMyPin = async(pinId) => {
+    
+  return await appDataSource.query(
+      `DELETE FROM pin p
+       WHERE p.id = ${pinId}
+         `,
+       )
+ }  
+
+const patchMyPin = async(pinId, boardId, title, contents) => {
+
+    return await appDataSource.query(
+        `UPDATE pin
+        SET 
+        title = ?,
+        contents = ?
+        WHERE id = ${pinId}
+        AND board_id = ${boardId}
+        `,[title, contents]
+    )
+}
+
 module.exports = {
-    getMainPinInfos,
-    getRecommendPins,
-    getPinInfo
+    getMainPinInfos, getRecommendPins, getPinInfo, checkMyPin, deleteMyPin, patchMyPin
 }

--- a/routes/pinRouter.js
+++ b/routes/pinRouter.js
@@ -7,6 +7,8 @@ const pinRouter = express.Router();
 pinRouter.get('/', errorHandler(auth.validationToken), errorHandler(pinController.findMainPins));
 pinRouter.get('/recommend/:tagId', errorHandler(auth.validationToken), errorHandler(pinController.findRecommendPins));
 pinRouter.get('/:pinId', pinController.getPinInfo);
+pinRouter.delete('/:pinId', errorHandler(auth.validationToken), pinController.deletePin);
+pinRouter.patch('/:pinId',errorHandler(auth.validationToken), pinController.patchPin)
 
 module.exports = {
     pinRouter

--- a/services/pinService.js
+++ b/services/pinService.js
@@ -1,4 +1,5 @@
 const pinDao = require('../models/pinDao');
+const ErrorCreater = require('../middlewares/errorCreater');
 
 const getMainPins = async(userId, pageSize, page) => {
     return await pinDao.getMainPinInfos(userId, pageSize = 10, page = 1);
@@ -14,8 +15,26 @@ const getPinInfo = async (pinId) => {
     return pinInfos;
 }
 
+const deletePin = async (pinId, userId) => {
+    
+    const checkMyPin = await pinDao.checkMyPin(pinId, userId)
+    
+    if(!checkMyPin)
+    {throw new ErrorCreater("INVAILD_ACCESS", 404)}
+    
+    return await pinDao.deleteMyPin(pinId);
+}
+
+const patchPin = async (pinId, boardId, title, contents, userId) => {
+    
+    const checkMyPin = await pinDao.checkMyPin(pinId, userId)
+    
+    if(!checkMyPin)
+    {throw new ErrorCreater("INVAILD_ACCESS", 404)}
+    
+    return await pinDao.patchMyPin(pinId, boardId, title, contents)
+}
+
 module.exports = {
-    getMainPins,
-    getRecommendPins,
-    getPinInfo
+getMainPins, getRecommendPins, getPinInfo, getPinInfo, deletePin, patchPin
 }


### PR DESCRIPTION
ADD: pin 수정 삭제 기능

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정



<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
수정하는 기능과 삭제하는 기능 (patch, delete)
1. 수정하는 기능과 삭제하는 기능 모두 수정, 삭제 전에 해당 핀이 자신이 생성한 핀이 맞는지 확인하고 아닌경우 error 처리합니다.
2. 모두 pinId를 query.params로 받고 받지 못한 값이 있는경우 error handling 했습니다.




<br />



<br />

## :: 기타 질문 및 특이 사항
핀 수정의 경우 프론트와 협의해서 핀 내의 사진은 수정하지 못하고 title과 contents만 수정 가능하도록 했으며
핀 삭제의 경우 처음에는 aws 에 올라간 사진마저 삭제되도록 구현하려고 했으나 이게 aws안에 사진 목록을 조회하고 - > aws 안에 해당 사진을 삭제하는 flow인 것 같아서 시간이 좀 걸릴 것 같아서 일단은 데이터 베이스 내에서의 링크 정보만 지울수 있도록 구현했습니다.
